### PR TITLE
Add financial data endpoints to proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ By Justin Rothweiler and Mark Bekker
 * `npm start` : starts the frontend client on localhost:3000
 * `npm run server` : starts the proxy server on localhost:3001
 * `npm run dev` : starts up both the frontend client and proxy server in parallel
+
+# Server
+
+This application uses the [iexcloud_api_wrapper](https://github.com/schardtbc/iexcloud_api_wrapper) JavaScript library in a proxy server as a wrapper for calls to IEX Cloud, the API for our financial data. In order to use this library, the following config must be added to a `.env` file (fill in with actual public/secret keys from IEX Cloud):
+
+```
+IEXCLOUD_API_VERSION = "stable"
+IEXCLOUD_PUBLIC_KEY = "pk_..."
+IEXCLOUD_SECRET_KEY = "sk_..." 
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,6 +1678,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
     },
+    "@types/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-Ygc2l1zQRuuQL9WwE7BDn7M++X4JuHgJpSTrSo/CRt/Eao268rv4hpyv4H2TlZqQ1nYt/I4Wkwbpqg8Xjz5shA=="
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -2502,6 +2507,43 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -6800,6 +6842,33 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "iexcloud_api_wrapper": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iexcloud_api_wrapper/-/iexcloud_api_wrapper-1.1.5.tgz",
+      "integrity": "sha512-9RnrspefNSCUlt9t9Po6B2PDzCEYxb7pCVkR0/YLhydXjqp0NLsT7ak4VFy60wDYMmsUr7UgzXGPa1HUBfP72g==",
+      "requires": {
+        "@types/dotenv": "6.1.0",
+        "@types/eventsource": "1.1.0",
+        "axios": "0.19.0",
+        "dotenv": "6.2.0",
+        "eventsource": "1.0.7"
+      },
+      "dependencies": {
+        "@types/dotenv": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.0.tgz",
+          "integrity": "sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "dotenv": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+        }
+      }
     },
     "iferr": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "iexcloud_api_wrapper": "^1.1.5",
     "node-env-run": "^3.0.2",
     "nodemon": "^2.0.4",
     "npm-run-all": "^4.1.5",

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ app.get('/api/news/:symbol', async (req, res) => {
     const newsData = await iex.news(symbol, 5);
     res.setHeader('Content-Type', 'application/json');
     const returnData = newsData.map(article => {
-        const {datetime, headline, source, url, summary} = article;
+        const {datetime, headline, source, url} = article;
         return {datetime, headline, source, url, summary};
     })
     

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ app.get('/api/quote/:symbol', async (req, res) => {
     const symbol = req.params.symbol;
     const quoteData = await iex.quote(symbol);
     res.setHeader('Content-Type', 'application/json');
-    const { previousClose, high, low, latestPrice, latestVolume, marketCap, open, avgTotalVolume } = quoteData;
+    const { previousClose, week52High, week52Low, high, low, latestPrice, latestVolume, marketCap, open, avgTotalVolume } = quoteData;
     res.send(JSON.stringify({ previousClose, week52High, week52Low, high, low, latestPrice, marketCap, latestVolume, open, avgTotalVolume }));
 });
 
@@ -35,7 +35,7 @@ app.get('/api/news/:symbol', async (req, res) => {
     res.setHeader('Content-Type', 'application/json');
     const returnData = newsData.map(article => {
         const {datetime, headline, source, url} = article;
-        return {datetime, headline, source, url, summary};
+        return {datetime, headline, source, url};
     })
     
     res.send(JSON.stringify(returnData));

--- a/server/index.js
+++ b/server/index.js
@@ -1,13 +1,44 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const iex = require( 'iexcloud_api_wrapper' )
 
 const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));
 
-app.get('/api/greeting', (req, res) => {
-  const name = req.query.name || 'World';
-  res.setHeader('Content-Type', 'application/json');
-  res.send(JSON.stringify({ greeting: `Hello ${name}!` }));
+app.get('/api/quote/:symbol', async (req, res) => {
+    const symbol = req.params.symbol;
+    const quoteData = await iex.quote(symbol);
+    res.setHeader('Content-Type', 'application/json');
+    const { previousClose, high, low, latestPrice, latestVolume, marketCap, open, avgTotalVolume } = quoteData;
+    res.send(JSON.stringify({ previousClose, high, low, latestPrice, marketCap, latestVolume, open, avgTotalVolume }));
+});
+
+app.get('/api/stats/:symbol', async (req, res) => {
+    const symbol = req.params.symbol;
+    const statData = await iex.keyStats(symbol);
+    res.setHeader('Content-Type', 'application/json');
+    const { dividendYield, ttmEPS, peRatio } = statData;
+    res.send(JSON.stringify({ dividendYield, earningsPerShare: ttmEPS, peRatio}));
+});
+
+app.get('/api/company/:symbol', async (req, res) => {
+    const symbol = req.params.symbol;
+    const companyData = await iex.company(symbol);
+    res.setHeader('Content-Type', 'application/json');
+    const { companyName, website, description } = companyData;
+    res.send(JSON.stringify({ companyName, website, description }));
+});
+
+app.get('/api/news/:symbol', async (req, res) => {
+    const symbol = req.params.symbol;
+    const newsData = await iex.news(symbol, 5);
+    res.setHeader('Content-Type', 'application/json');
+    const returnData = newsData.map(article => {
+        const {datetime, headline, source, url, summary} = article;
+        return {datetime, headline, source, url, summary};
+    })
+    
+    res.send(JSON.stringify(returnData));
 });
 
 app.listen(3001, () =>

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ app.get('/api/quote/:symbol', async (req, res) => {
     const quoteData = await iex.quote(symbol);
     res.setHeader('Content-Type', 'application/json');
     const { previousClose, high, low, latestPrice, latestVolume, marketCap, open, avgTotalVolume } = quoteData;
-    res.send(JSON.stringify({ previousClose, high, low, latestPrice, marketCap, latestVolume, open, avgTotalVolume }));
+    res.send(JSON.stringify({ previousClose, week52High, week52Low, high, low, latestPrice, marketCap, latestVolume, open, avgTotalVolume }));
 });
 
 app.get('/api/stats/:symbol', async (req, res) => {

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -1,0 +1,3 @@
+export const proxyFetch = (symbol, endpoint) => {
+    return fetch(`/api/${endpoint}/${symbol}`).then(data => data.json());
+}

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -1,3 +1,27 @@
+// Helper functions for fetching financial data from the proxy server
+// See server/index.js for server code.
+
+// Generalized fetch function over any endpoint
 export const proxyFetch = (symbol, endpoint) => {
     return fetch(`/api/${endpoint}/${symbol}`).then(data => data.json());
+}
+
+// Fetches real time information (price, volume, high, low, etc) for the symbol
+export const quoteFetch = (symbol) => {
+    return fetch(`/api/quote/${symbol}`).then(data => data.json());
+}
+
+// Fetches company information 
+export const companyFetch = (symbol) => {
+    return fetch(`/api/company/${symbol}`).then(data => data.json());
+}
+
+// Fetches symbol statistics (PE ratio, dividend yield, etc.), data points which are generally not real-time.
+export const statsFetch = (symbol) => {
+    return fetch(`/api/stats/${symbol}`).then(data => data.json());
+}
+
+// Fetches news articles for the company, 5 for each call.
+export const newsFetch = (symbol) => {
+    return fetch(`/api/quote/${symbol}`).then(data => data.json());
 }


### PR DESCRIPTION
This PR adds to the proxy server, creating four endpoints that we will need in order to pull data for our application. The proxy server handles making requests to IEX cloud, filtering requests to only the data that we are interested in consuming on the front end. A general helper function is also provided for making a request to this proxy API, for a given symbol and to a given endpoint. 