### PR TITLE
Reset search errors on search

### DIFF
--- a/src/components/searchBar.js
+++ b/src/components/searchBar.js
@@ -28,6 +28,7 @@ const SearchBar = () => {
             dispatch({ type: 'searchSymbol', payload: currentText.toUpperCase()} );
             setCurrentText('');
             setShowBadInputError(false);
+            dispatch({ type: 'clearSearchErrors' })
         } else {
             setShowBadInputError(true);
         }

--- a/src/reducers/errorReducer.js
+++ b/src/reducers/errorReducer.js
@@ -10,6 +10,11 @@ export default (state = initialState, action) => {
                 ...state,
                 search: action.payload
             }
+        case 'clearSearchErrors': 
+            return {
+                ...state, 
+                search: null
+            }
         default: 
             return state;
     }


### PR DESCRIPTION
A small bug in the search PR recently merged: any server errors stored in the redux state are never cleared, meaning they will forever show in the UI. This PR sends a clear action to redux after initiating another search.