### PR TITLE
Compute missing data

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,36 @@ async function fetchWrapper(...args) {
   }
 }
 
+async function getQuoteData(symbol) {
+    const [quoteData, dailyData] = await Promise.all([fetchWrapper(iex.quote, symbol), fetchWrapper(iex.history, symbol, { period: '1d' })]);
+    
+    // some data has been deprecated from the quote api, so as a workaround, calculate these fields off of the current day's price data minute by minute.
+    const high = Math.max(...dailyData.map(minute => minute.high));
+    const low = Math.min(...dailyData.map(minute => minute.low));
+    const latestVolume = dailyData.reduce((acc, currentMinute) => currentMinute.volume + acc, 0)
+    const open = dailyData[0]?.open || null;
+    const {
+      previousClose,
+      week52High,
+      week52Low,
+      latestPrice,
+      marketCap,
+      avgTotalVolume,
+    } = quoteData;
+    return {
+      previousClose,
+      week52High,
+      week52Low,
+      high,
+      low,
+      latestPrice,
+      marketCap,
+      latestVolume,
+      open,
+      avgTotalVolume,
+    };
+}
+
 //iex.marketSymbols().then((data) => console.log(data));
 app.use(bodyParser.urlencoded({ extended: false }));
 
@@ -38,31 +68,8 @@ app.get("/api/quote/:symbol", async (req, res) => {
   console.log("app.get quotes");
   const symbol = req.params.symbol;
   try {
-    const quoteData = await fetchWrapper(iex.quote, symbol);
-    const {
-      previousClose,
-      week52High,
-      week52Low,
-      high,
-      low,
-      latestPrice,
-      latestVolume,
-      marketCap,
-      open,
-      avgTotalVolume,
-    } = quoteData;
-    res.json({
-      previousClose,
-      week52High,
-      week52Low,
-      high,
-      low,
-      latestPrice,
-      marketCap,
-      latestVolume,
-      open,
-      avgTotalVolume,
-    });
+    let quoteData = await getQuoteData(symbol)
+    res.json(quoteData);
   } catch (e) {
     res.sendStatus(e.response.status);
   }
@@ -130,31 +137,8 @@ io.on("connection", (socket) => {
 
   let subscribeToSymbol = (symbol) => {
     return setInterval(async () => {
-      const quoteData = await fetchWrapper(iex.quote, symbol);
-      const {
-        previousClose,
-        week52High,
-        week52Low,
-        high,
-        low,
-        latestPrice,
-        latestVolume,
-        marketCap,
-        open,
-        avgTotalVolume,
-      } = quoteData;
-      socket.emit("realTimeQuoteData", {
-        previousClose,
-        week52High,
-        week52Low,
-        high,
-        low,
-        latestPrice,
-        latestVolume,
-        marketCap,
-        open,
-        avgTotalVolume,
-      });
+      let quoteData = await getQuoteData(symbol)
+      socket.emit("realTimeQuoteData", quoteData);
     }, 1000);
   };
 

--- a/src/components/keyStats.js
+++ b/src/components/keyStats.js
@@ -46,7 +46,7 @@ export const KeyStats = () => {
             {quote && 
             <StatWrapper>
                 <Text variant="statLabel">Open</Text>
-                <Text display="statValue">{quote.open}</Text>
+                <Text variant="statValue">{quote.open}</Text>
             </StatWrapper>}
             {quote && 
             <StatWrapper>


### PR DESCRIPTION
This PR computes some missing data on the server end for the key stats, implemented in card 322. Since the quote API always sends null values for open price, high/low, and volume, this approach fetches that data from the daily historical data. Given the volumes, high/low, etc. for each minute of the day, we can calculate the totals across the day and have a relatively accurate value for these missing fields.