### PR TITLE
Chart time intervals

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -116,10 +116,10 @@ app.get("/api/news/:symbol", async (req, res) => {
   }
 });
 
-app.get('/api/history/:symbol/:period', async (req,res) => {
+app.get('/api/history/:symbol', async (req,res) => {
     console.log("app.get history");
     const symbol = req.params.symbol;
-    let period = req.params.period;
+    let period = req.query.period;
     // if the user wants 5d, give them interday data
     if (period === '5d') {
       period = '5dm';

--- a/server/index.js
+++ b/server/index.js
@@ -121,8 +121,8 @@ app.get('/api/history/:symbol', async (req,res) => {
     const symbol = req.params.symbol;
     let period = req.query.period;
     // if the user wants 5d, give them interday data
-    if (period === '5d') {
-      period = '5dm';
+    if (period === '5D') {
+      period = '5DM';
     }
 
     try {

--- a/server/index.js
+++ b/server/index.js
@@ -116,16 +116,23 @@ app.get("/api/news/:symbol", async (req, res) => {
   }
 });
 
-app.get('/api/history/:symbol', async (req,res) => {
+app.get('/api/history/:symbol/:period', async (req,res) => {
     console.log("app.get history");
     const symbol = req.params.symbol;
+    let period = req.params.period;
+    // if the user wants 5d, give them interday data
+    if (period === '5d') {
+      period = '5dm';
+    }
+
     try {
-        const historyData = await fetchWrapper(iex.history, symbol, { period: '1d' });
+        const historyData = await fetchWrapper(iex.history, symbol, { period: period });
+        console.log(historyData);
         const returnData = historyData.map(day => {
             return {
                 date: day.date,
                 minute: day.minute,
-                price: day.average
+                price: day.average || day.close
             }
         })
         res.json(returnData);

--- a/server/index.js
+++ b/server/index.js
@@ -120,18 +120,20 @@ app.get('/api/history/:symbol', async (req,res) => {
     console.log("app.get history");
     const symbol = req.params.symbol;
     let period = req.query.period;
-    // if the user wants 5d, give them interday data
+    // if the user wants 5d, give them minute by minute data
     if (period === '5D') {
       period = '5DM';
     }
 
     try {
-        const historyData = await fetchWrapper(iex.history, symbol, { period: period });
-        console.log(historyData);
+        const historyData = await fetchWrapper(iex.history, symbol, { period });
         const returnData = historyData.map(day => {
             return {
                 date: day.date,
                 minute: day.minute,
+
+                // if the data is minute to minute, go by average price for that period
+                // on a day by day frequency, go by the closing price
                 price: day.average || day.close
             }
         })

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ const producerMiddleWare = (rawStore) => {
           companyFetch(symbol),
           newsFetch(symbol),
           statsFetch(symbol),
-          historyFetch(symbol, '5d'),
+          historyFetch(symbol, '1m'),
         ])
           .then((dataArray) => {
             let [

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ const producerMiddleWare = (rawStore) => {
           companyFetch(symbol),
           newsFetch(symbol),
           statsFetch(symbol),
-          historyFetch(symbol),
+          historyFetch(symbol, '5d'),
         ])
           .then((dataArray) => {
             let [

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import {
   statsFetch,
   historyFetch,
 } from "./utils/serverUtils";
-import { INITIAL_STOCK, INITIAL_CHART_RANGE } from "./utils/constants";
+import { INITIAL_STOCK } from "./utils/constants";
 import SearchBar from "./components/searchBar";
 import socketIOClient from "socket.io-client";
 import { PriceDisplay } from "./components/priceDisplay";

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import {
   statsFetch,
   historyFetch,
 } from "./utils/serverUtils";
-import { INITIAL_STOCK } from "./utils/constants";
+import { INITIAL_STOCK, INITIAL_CHART_RANGE } from "./utils/constants";
 import SearchBar from "./components/searchBar";
 import socketIOClient from "socket.io-client";
 import { PriceDisplay } from "./components/priceDisplay";
@@ -34,7 +34,6 @@ const producerMiddleWare = (rawStore) => {
           companyFetch(symbol),
           newsFetch(symbol),
           statsFetch(symbol),
-          historyFetch(symbol, '1m'),
         ])
           .then((dataArray) => {
             let [
@@ -42,7 +41,6 @@ const producerMiddleWare = (rawStore) => {
               companyInfo,
               newsInfo,
               statInfo,
-              historyInfo,
             ] = dataArray;
             rawStore.dispatch({
               type: "newTickerData",
@@ -53,7 +51,6 @@ const producerMiddleWare = (rawStore) => {
                   newsInfo,
                   companyInfo,
                   statInfo,
-                  historyInfo,
                 },
               },
             });
@@ -63,6 +60,13 @@ const producerMiddleWare = (rawStore) => {
           .catch((e) => {
             rawStore.dispatch({ type: "searchError", payload: e.message });
           });
+        break;
+      }
+      case 'fetchHistory': {
+        let { symbol, period } = action.payload;
+        historyFetch(symbol, period).then(data => {
+          rawStore.dispatch({ type: "newHistoryData", payload: data })
+        })
       }
       default:
         rawStore.dispatch(action);

--- a/src/components/generics/button.js
+++ b/src/components/generics/button.js
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { layout, typography, variant, space, color, border } from "styled-system";
+import { variant, color, border } from "styled-system";
 
 export const Button = styled('button')(
     color, 

--- a/src/components/generics/button.js
+++ b/src/components/generics/button.js
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { layout, typography, variant, space, color, border } from "styled-system";
+
+export const Button = styled('button')(
+    color, 
+    border,
+    variant({
+        variants: {
+            unstyled: {
+                background: 'none',
+                border: 'none',
+                outline: 'none'
+            }
+        }
+    })
+)

--- a/src/components/generics/displayWrapper.js
+++ b/src/components/generics/displayWrapper.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
-import { layout, space } from "styled-system";
+import { layout, space, flexbox } from "styled-system";
 export const DisplayWrapper = styled.div`
   ${layout};
   ${space};
+  ${flexbox}
 `;

--- a/src/components/searchBar.js
+++ b/src/components/searchBar.js
@@ -5,12 +5,14 @@ import Icon from "@mdi/react";
 import { VALID_SEARCH_REGEXP } from "../utils/constants";
 import { Text } from "../components/generics/text";
 import { searchErrorsSelector } from "../selectors/errorsSelectors";
+import { chartRangeSelector } from '../selectors/historySelector';
 
 const SearchBar = () => {
   let [currentText, setCurrentText] = useState("");
   let [showBadInputError, setShowBadInputError] = useState(false);
   let [showCompanyText, setShowCompanyText] = useState(true);
   let searchError = useSelector(searchErrorsSelector);
+  let chartRange = useSelector(chartRangeSelector);
   let companyName =
     useSelector(
       (state) => state?.stocks?.tickerInfo?.companyInfo?.companyName

--- a/src/components/searchBar.js
+++ b/src/components/searchBar.js
@@ -5,14 +5,12 @@ import Icon from "@mdi/react";
 import { VALID_SEARCH_REGEXP } from "../utils/constants";
 import { Text } from "../components/generics/text";
 import { searchErrorsSelector } from "../selectors/errorsSelectors";
-import { chartRangeSelector } from '../selectors/historySelector';
 
 const SearchBar = () => {
   let [currentText, setCurrentText] = useState("");
   let [showBadInputError, setShowBadInputError] = useState(false);
   let [showCompanyText, setShowCompanyText] = useState(true);
   let searchError = useSelector(searchErrorsSelector);
-  let chartRange = useSelector(chartRangeSelector);
   let companyName =
     useSelector(
       (state) => state?.stocks?.tickerInfo?.companyInfo?.companyName

--- a/src/components/visualDisplay.js
+++ b/src/components/visualDisplay.js
@@ -7,6 +7,7 @@ import { currentPriceSelector } from '../selectors/quoteSelector';
 import { tickerSelector } from '../selectors/tickerSelector';
 import { POSSIBLE_CHART_RANGES } from '../utils/constants';
 import { Text } from '../components/generics/text';
+import { Button } from '../components/generics/button';
 import 'chartjs-plugin-annotation';
 
 
@@ -20,7 +21,7 @@ export const VisualDisplay = () => {
   const currentPrice = useSelector(currentPriceSelector)
   
   const chartRange = useSelector(chartRangeSelector);
-  const historyData = useSelector(historySelector); 
+  const historyData = useSelector(historySelector) || []; 
   const currentSymbol = useSelector(tickerSelector);
 
   const handleChartRangeClick = (period) => {
@@ -33,11 +34,6 @@ export const VisualDisplay = () => {
     }
     
   }, [currentSymbol, chartRange])
-
-
-  if (!historyData || !currentPrice) {
-    return ( <div>loading</div>)
-  }
 
   let formattedHistoryData = historyData.map((point) => {
     return {
@@ -119,11 +115,15 @@ export const VisualDisplay = () => {
 
   return (
     <DisplayWrapper width="80%">
-      {
-        POSSIBLE_CHART_RANGES.map(period => (
-          <Text mr="8px" display="inline-block" variant={period === chartRange ? "primary" : "secondary"} onClick={() => handleChartRangeClick(period)}>{period}</Text>
-        ))
-      }
+      <DisplayWrapper display="flex" justifyContent="flex-end" mb="8px">
+        {
+          POSSIBLE_CHART_RANGES.map(period => (
+          <Button variant="unstyled" mr="8px"  onClick={() => handleChartRangeClick(period)}>
+            <Text variant={period === chartRange ? "primary" : "secondary"}>{period}</Text>
+          </Button>
+          ))
+        }
+      </DisplayWrapper>
       <Line ref={chartRef} data={data} options={options} plugins={plugins}/>
     </DisplayWrapper>
   );

--- a/src/components/visualDisplay.js
+++ b/src/components/visualDisplay.js
@@ -79,8 +79,17 @@ export const VisualDisplay = () => {
     scales: {
       xAxes: [{
         type: 'time',
+        distribution: "series",
         time: {
-          format: 'YYYY-MM-DD HH:mm'
+          minUnit: 'hour',
+          displayFormats: {
+            hour: 'MMM DD  h:mm a'
+          },
+          format: 'YYYY-MM-DD HH:mm',
+        },
+        ticks: {
+          autoSkip: true,
+          maxTicksLimit: 10
         },
         gridLines: {
           display: true,

--- a/src/components/visualDisplay.js
+++ b/src/components/visualDisplay.js
@@ -10,8 +10,6 @@ import { Text } from '../components/generics/text';
 import { Button } from '../components/generics/button';
 import 'chartjs-plugin-annotation';
 
-
-
 export const VisualDisplay = () => {
 
   const dispatch = useDispatch();

--- a/src/components/visualDisplay.js
+++ b/src/components/visualDisplay.js
@@ -5,7 +5,11 @@ import { useSelector, useDispatch } from "react-redux";
 import { historySelector, chartRangeSelector } from '../selectors/historySelector';
 import { currentPriceSelector } from '../selectors/quoteSelector';
 import { tickerSelector } from '../selectors/tickerSelector';
+import { POSSIBLE_CHART_RANGES } from '../utils/constants';
+import { Text } from '../components/generics/text';
 import 'chartjs-plugin-annotation';
+
+
 
 export const VisualDisplay = () => {
 
@@ -18,6 +22,10 @@ export const VisualDisplay = () => {
   const chartRange = useSelector(chartRangeSelector);
   const historyData = useSelector(historySelector); 
   const currentSymbol = useSelector(tickerSelector);
+
+  const handleChartRangeClick = (period) => {
+    dispatch({ type: 'newChartRange', payload: period })
+  }
 
   useEffect(() => {
     if (currentSymbol) {
@@ -33,7 +41,7 @@ export const VisualDisplay = () => {
 
   let formattedHistoryData = historyData.map((point) => {
     return {
-      x: `${point.date} ${point.minute}`,
+      x: point.minute ? `${point.date} ${point.minute}` : point.date,
       y: point.price,
     };
   });
@@ -111,6 +119,11 @@ export const VisualDisplay = () => {
 
   return (
     <DisplayWrapper width="80%">
+      {
+        POSSIBLE_CHART_RANGES.map(period => (
+          <Text mr="8px" display="inline-block" variant={period === chartRange ? "primary" : "secondary"} onClick={() => handleChartRangeClick(period)}>{period}</Text>
+        ))
+      }
       <Line ref={chartRef} data={data} options={options} plugins={plugins}/>
     </DisplayWrapper>
   );

--- a/src/components/visualDisplay.js
+++ b/src/components/visualDisplay.js
@@ -1,18 +1,32 @@
-import React, {useRef} from "react";
+import React, {useRef, useEffect} from "react";
 import { DisplayWrapper } from "./generics/displayWrapper";
 import { Line } from "react-chartjs-2";
-import { useSelector } from "react-redux";
-import { historySelector } from '../selectors/historySelector';
+import { useSelector, useDispatch } from "react-redux";
+import { historySelector, chartRangeSelector } from '../selectors/historySelector';
 import { currentPriceSelector } from '../selectors/quoteSelector';
+import { tickerSelector } from '../selectors/tickerSelector';
 import 'chartjs-plugin-annotation';
 
 export const VisualDisplay = () => {
 
+  const dispatch = useDispatch();
+
   const chartRef = useRef();
 
   const currentPrice = useSelector(currentPriceSelector)
-
+  
+  const chartRange = useSelector(chartRangeSelector);
   const historyData = useSelector(historySelector); 
+  const currentSymbol = useSelector(tickerSelector);
+
+  useEffect(() => {
+    if (currentSymbol) {
+      dispatch({ type: 'fetchHistory', payload: { symbol: currentSymbol, period: chartRange }})
+    }
+    
+  }, [currentSymbol, chartRange])
+
+
   if (!historyData || !currentPrice) {
     return ( <div>loading</div>)
   }

--- a/src/reducers/stockReducer.js
+++ b/src/reducers/stockReducer.js
@@ -2,7 +2,7 @@ import { INITIAL_CHART_RANGE } from '../utils/constants';
 
 const initialState = {
   ticker: null,
-  chartRange: '1d',
+  chartRange: INITIAL_CHART_RANGE,
   tickerInfo: {
     quoteInfo: null,
     newsInfo: null,

--- a/src/reducers/stockReducer.js
+++ b/src/reducers/stockReducer.js
@@ -1,5 +1,8 @@
+import { INITIAL_CHART_RANGE } from '../utils/constants';
+
 const initialState = {
   ticker: null,
+  chartRange: '1d',
   tickerInfo: {
     quoteInfo: null,
     newsInfo: null,
@@ -24,8 +27,27 @@ export default (state = initialState, action) => {
       return {
         ...state,
         ticker: action.payload.symbol,
-        tickerInfo: action.payload.data,
+        tickerInfo: { 
+          ...state.tickerInfo,
+          ...action.payload.data
+        },
       };
+    }
+    case "newHistoryData": {
+      return {
+        ...state,
+        tickerInfo: {
+          ...state.tickerInfo, 
+          historyInfo: action.payload
+          
+        }
+      }
+    }
+    case "newChartRange": {
+      return {
+        ...state, 
+        chartRange: action.payload
+      }
     }
     default:
       return state;

--- a/src/selectors/historySelector.js
+++ b/src/selectors/historySelector.js
@@ -1,3 +1,5 @@
 export const historySelector = (state) => {
   return state.stocks.tickerInfo.historyInfo;
 };
+
+export const chartRangeSelector = (state) => state.stocks.chartRange;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,2 +1,3 @@
 export const INITIAL_STOCK = "AAPL";
 export const VALID_SEARCH_REGEXP = /^[A-Za-z]+$/;
+export const INITIAL_CHART_RANGE = '1d';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,4 @@
 export const INITIAL_STOCK = "AAPL";
 export const VALID_SEARCH_REGEXP = /^[A-Za-z]+$/;
-export const INITIAL_CHART_RANGE = '1y';
-export const POSSIBLE_CHART_RANGES = ['1d', '5d', '1m', '1y', '5y', 'max']
+export const INITIAL_CHART_RANGE = '1Y';
+export const POSSIBLE_CHART_RANGES = ['1D', '5D', '1M', '1Y', '5Y', 'MAX']

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,4 @@
 export const INITIAL_STOCK = "AAPL";
 export const VALID_SEARCH_REGEXP = /^[A-Za-z]+$/;
-export const INITIAL_CHART_RANGE = '1d';
+export const INITIAL_CHART_RANGE = '1y';
+export const POSSIBLE_CHART_RANGES = ['1d', '5d', '1m', '1y', '5y', 'max']

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -32,6 +32,7 @@ export const newsFetch = (symbol) => {
   return proxyFetch(symbol, "news");
 };
 
-export const historyFetch = (symbol) => {
-  return proxyFetch(symbol, "history");
+// collect historical data over the given period, either "1d", "5d", "1m", "1y", "5y", or "max"
+export const historyFetch = (symbol, period) => {
+  return proxyFetch(`${symbol}/${period}`, `history`);
 };

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -39,7 +39,7 @@ export const newsFetch = (symbol) => {
   return proxyFetch(symbol, "news");
 };
 
-// collect historical data over the given period, either "1d", "5d", "1m", "1y", "5y", or "max"
+// collect historical data over the given period, either "1D", "5D", "1M", "1Y", "5Y", or "MAX"
 export const historyFetch = (symbol, period) => {
   return proxyFetch(symbol, `history`, { period });
 };

--- a/src/utils/serverUtils.js
+++ b/src/utils/serverUtils.js
@@ -2,8 +2,15 @@
 // See server/index.js for server code.
 
 // Generalized fetch function over any endpoint
-export const proxyFetch = async (symbol, endpoint) => {
-  return fetch(`/api/${endpoint}/${symbol}`).then((data) => {
+export const proxyFetch = async (symbol, endpoint, queryParams) => {
+  // unfortunately, fetch does not support a query object, so we need 
+  // to build the query string ourselves.
+  let queryString = queryParams ? '?' : '';
+  for (let field in queryParams) {
+    queryString += `${field}=${queryParams[field]}`;
+  }
+
+  return fetch(`/api/${endpoint}/${symbol}${queryString}`).then((data) => {
     if (data.ok) {
       return data.json();
     } else {
@@ -34,5 +41,5 @@ export const newsFetch = (symbol) => {
 
 // collect historical data over the given period, either "1d", "5d", "1m", "1y", "5y", or "max"
 export const historyFetch = (symbol, period) => {
-  return proxyFetch(`${symbol}/${period}`, `history`);
+  return proxyFetch(symbol, `history`, { period });
 };


### PR DESCRIPTION
Implements card 334

This PR adds buttons for fetching varying time intervals of historic data for the chart. The high level approach was to move the history fetching to its own action in the middleware, which is then connected to the buttons above the chart. I needed to do some interesting things to get the x axis time labels on 1 day and 5 day data formatting appropriately, since they were both showing just the hour and minute but 5 day should also show the day. 

![image](https://user-images.githubusercontent.com/36375152/88202515-ff223480-cc16-11ea-8b34-b1b9a88b9b27.png)
