### PR TITLE
Company info badges

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ async function fetchWrapper(...args) {
   } catch (e) {
     if (e.response.status === 429) {
       // in the case of Too Many Requests, wait 100ms and try again
-      await delay(100);
+      await delay(1000);
       return fetchWrapper(...args);
     } else {
       // Propogate all other errors
@@ -108,8 +108,10 @@ app.get("/api/company/:symbol", async (req, res) => {
   const symbol = req.params.symbol;
   try {
     const companyData = await fetchWrapper(iex.company, symbol);
-    const { companyName, website, description } = companyData;
-    res.json({ companyName, website, description });
+    const financialData = await fetchWrapper(iex.financials, symbol);
+    const { companyName, website, description, exchange, sector } = companyData;
+    const { currency } = financialData[0];
+    res.json({ companyName, website, description, exchange, sector, currency });
   } catch (e) {
     res.sendStatus(e.response.status);
   }

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,6 @@ async function fetchWrapper(...args) {
     return data;
   } catch (e) {
     if (e.response.status === 429) {
-      console.log("retrying");
       // in the case of Too Many Requests, wait 1s and try again
       await delay(1000);
       return fetchWrapper(...args);

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,8 @@ async function fetchWrapper(...args) {
     return data;
   } catch (e) {
     if (e.response.status === 429) {
-      // in the case of Too Many Requests, wait 100ms and try again
+      console.log("retrying");
+      // in the case of Too Many Requests, wait 1s and try again
       await delay(1000);
       return fetchWrapper(...args);
     } else {
@@ -191,7 +192,7 @@ io.on("connection", (socket) => {
           socket.emit("realTimeIndexData", dataArray);
         }
       );
-    }, 5000);
+    }, 6000);
   };
 
   let intervalId = null;

--- a/src/App.js
+++ b/src/App.js
@@ -118,10 +118,10 @@ const dataStore = producerMiddleWare(
 function App() {
   useEffect(() => {
     dataStore.dispatch({ type: "searchSymbol", payload: INITIAL_STOCK });
-    dataStore.dispatch({
+    /*dataStore.dispatch({
       type: "searchIndexes",
       payload: ["MSFT", "GOOGL", "AMZN"],
-    });
+    });*/
   }, []);
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -14,8 +14,8 @@ import {
 import { INITIAL_STOCK } from "./utils/constants";
 import socketIOClient from "socket.io-client";
 import { StockTrader } from "./stockTrader";
-import { ThemeProvider } from 'styled-components'
-import theme from './themes/theme';
+import { ThemeProvider } from "styled-components";
+import theme from "./themes/theme";
 
 //Triggers dispatches (May need to be broken down into multiple Middlewares chained together)
 const producerMiddleWare = (rawStore) => {
@@ -117,10 +117,10 @@ const dataStore = producerMiddleWare(
 function App() {
   useEffect(() => {
     dataStore.dispatch({ type: "searchSymbol", payload: INITIAL_STOCK });
-    /*dataStore.dispatch({
+    dataStore.dispatch({
       type: "searchIndexes",
       payload: ["MSFT", "GOOGL", "AMZN"],
-    }); */
+    });
   }, []);
 
   return (

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,29 +6,25 @@ import {
   fireEvent,
 } from "@testing-library/react";
 import App from "./App";
-import { SocketIO, Server } from 'mock-socket';
-import socketIOClient from 'socket.io-client';
+import socketIOClient from "socket.io-client";
 
-// mock the socket io client with an object that resembles a socket 
-jest.mock('socket.io-client', () => {
+// mock the socket io client with an object that resembles a socket
+jest.mock("socket.io-client", () => {
   const emit = jest.fn();
   // keep track in this mock of any callbacks added through 'on'
-  const eventHandlers = {}
+  const eventHandlers = {};
   const on = jest.fn((event, cb) => {
-    eventHandlers[event] = cb
+    eventHandlers[event] = cb;
   });
 
   // test helper that simulates the socket receiving an event from the server
   // side of the socket, calling the appropriate callback
   const receiveEvent = (event, ...args) => {
     eventHandlers[event](...args);
-  }
+  };
   const socket = { emit, on, receiveEvent };
   return jest.fn(() => socket);
 });
-
-
-
 
 // Integration tests for the general application experience
 describe("Application", () => {
@@ -40,7 +36,7 @@ describe("Application", () => {
 
   afterEach(() => {
     appData.unmount();
-  })
+  });
 
   test("Renders all the expected sections of the experience", () => {
     // test that the major sections all appear as headers (banner role)
@@ -63,19 +59,19 @@ describe("Application", () => {
     expect(screen.getByText("Apple description")).toBeInTheDocument(); // company overview
     expect(screen.getByText("PHQ")).toBeInTheDocument(); // company overview
     expect(screen.getByText("387.46")).toBeInTheDocument(); // big price
-
+    expect(screen.getByText("NASDAQ")).toBeInTheDocument(); // company badges
   });
 
-  test('a socket connection is made', () => {
+  test("a socket connection is made", () => {
     expect(socketIOClient).toHaveBeenCalled();
-  })
+  });
 
-  test('responds to real time quote data events by updating UI', () => {
+  test("responds to real time quote data events by updating UI", () => {
     // at first, it shows the mock data's price
     expect(screen.getByText("387.46")).toBeInTheDocument();
-    expect(screen.queryByText('400.46')).not.toBeInTheDocument();
+    expect(screen.queryByText("400.46")).not.toBeInTheDocument();
 
-    socketIOClient().receiveEvent('realTimeQuoteData', {
+    socketIOClient().receiveEvent("realTimeQuoteData", {
       previousClose: "479.47",
       week52High: "517.16",
       week52Low: "297.51",
@@ -86,17 +82,16 @@ describe("Application", () => {
       latestVolume: 115510,
       open: "492.56",
       avgTotalVolume: 35008228,
-    })
+    });
 
     // after the event, the UI reflects the new data
     expect(screen.queryByText("387.46")).not.toBeInTheDocument();
-    expect(screen.getByText('400.46')).toBeInTheDocument();
-    
-  })
+    expect(screen.getByText("400.46")).toBeInTheDocument();
+  });
 
-  test('searched symbols send newSymbol events over socket', async () => {
-    expect(socketIOClient().emit).toHaveBeenCalledWith('newSymbol', 'AAPL');
-    expect(socketIOClient().emit).not.toHaveBeenCalledWith('newSymbol', 'WORK');
+  test("searched symbols send newSymbol events over socket", async () => {
+    expect(socketIOClient().emit).toHaveBeenCalledWith("newSymbol", "AAPL");
+    expect(socketIOClient().emit).not.toHaveBeenCalledWith("newSymbol", "WORK");
 
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "WORK" } });
@@ -104,9 +99,8 @@ describe("Application", () => {
 
     await waitForElement(() => screen.getByText("Slack Technologies, Inc."));
 
-    expect(socketIOClient().emit).toHaveBeenCalledWith('newSymbol', 'WORK');
-  })
+    expect(socketIOClient().emit).toHaveBeenCalledWith("newSymbol", "WORK");
+  });
 
   // TODO: do integration test of footer index searches once we consistently hook that up to real data.
-
 });

--- a/src/components/companyBadges.js
+++ b/src/components/companyBadges.js
@@ -9,7 +9,7 @@ export const CompanyBadges = (props) => {
   return (
     <DisplayWrapper {...props} variant="flexRow" justifyContent="flex-start">
       {badgeInfo.map((badgeText, indx) => (
-        <DisplayBadge key={indx} mb="8px" mr="16px">
+        <DisplayBadge key={indx} mb="8px" mr="12px">
           {badgeText}
         </DisplayBadge>
       ))}

--- a/src/components/companyBadges.js
+++ b/src/components/companyBadges.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { companyBadgeInfoSelector } from "../selectors/companySelector";
+import { DisplayWrapper } from "./generics/displayWrapper";
+import { DisplayBadge } from "./generics/displayBadge";
+import { useDispatch, useSelector } from "react-redux";
+
+export const CompanyBadges = (props) => {
+  const badgeInfo = useSelector(companyBadgeInfoSelector);
+
+  return (
+    <DisplayWrapper {...props} variant="flexRow" justifyContent="flex-start">
+      {badgeInfo.map((badgeText) => (
+        <DisplayBadge mb="8px" mr="16px">
+          {badgeText}
+        </DisplayBadge>
+      ))}
+    </DisplayWrapper>
+  );
+};

--- a/src/components/companyBadges.js
+++ b/src/components/companyBadges.js
@@ -8,8 +8,8 @@ export const CompanyBadges = (props) => {
 
   return (
     <DisplayWrapper {...props} variant="flexRow" justifyContent="flex-start">
-      {badgeInfo.map((badgeText) => (
-        <DisplayBadge mb="8px" mr="16px">
+      {badgeInfo.map((badgeText, indx) => (
+        <DisplayBadge key={indx} mb="8px" mr="16px">
           {badgeText}
         </DisplayBadge>
       ))}

--- a/src/components/companyBadges.js
+++ b/src/components/companyBadges.js
@@ -1,11 +1,10 @@
 import React from "react";
-import { companyBadgeInfoSelector } from "../selectors/companySelector";
+import { useCompanyBadgeInfo } from "./componentHooks/useCompanyBadgeInfo";
 import { DisplayWrapper } from "./generics/displayWrapper";
 import { DisplayBadge } from "./generics/displayBadge";
-import { useDispatch, useSelector } from "react-redux";
 
 export const CompanyBadges = (props) => {
-  const badgeInfo = useSelector(companyBadgeInfoSelector);
+  const badgeInfo = useCompanyBadgeInfo();
 
   return (
     <DisplayWrapper {...props} variant="flexRow" justifyContent="flex-start">

--- a/src/components/companyBadges.test.js
+++ b/src/components/companyBadges.test.js
@@ -1,0 +1,30 @@
+import React from "react";
+import {
+  render,
+  screen,
+  waitForElement,
+  fireEvent,
+} from "@testing-library/react";
+import { CompanyBadges } from "./companyBadges";
+import { useCompanyBadgeInfo } from "../components/componentHooks/useCompanyBadgeInfo";
+
+jest.mock("./componentHooks/useCompanyBadgeInfo", () => ({
+  useCompanyBadgeInfo: () => {
+    return ["NASDAQ", "Technology", "USD"];
+  },
+}));
+
+// Tests for search bar functionality
+// Done as integration tests due to the dependencies across the
+// whole experience
+describe("Company badges component", () => {
+  beforeEach(async () => {
+    render(<CompanyBadges />);
+  });
+
+  test("Renders the data given", () => {
+    expect(screen.getByText("NASDAQ")).toBeInTheDocument();
+    expect(screen.getByText("Technology")).toBeInTheDocument();
+    expect(screen.getByText("USD")).toBeInTheDocument();
+  });
+});

--- a/src/components/componentHooks/useCompanyBadgeInfo.js
+++ b/src/components/componentHooks/useCompanyBadgeInfo.js
@@ -1,0 +1,4 @@
+import { useSelector } from "react-redux";
+import { companyBadgeInfoSelector } from "../../selectors/companySelector";
+
+export const useCompanyBadgeInfo = () => useSelector(companyBadgeInfoSelector);

--- a/src/components/generics/displayBadge.js
+++ b/src/components/generics/displayBadge.js
@@ -1,10 +1,14 @@
 import styled from "styled-components";
+import { space } from "styled-system";
 
-export const DisplayBadge = styled.button`
+export const DisplayBadge = styled.div`
   font-family: Arial;
   font-size: 1rem;
   border: none;
   padding: 7px 10px;
-  background: #41608a;
+  background: #415f8a;
   color: white;
+  max-width: max-content;
+  border-radius: 2px;
+  ${space}
 `;

--- a/src/selectors/companySelector.js
+++ b/src/selectors/companySelector.js
@@ -1,3 +1,12 @@
+import { createSelector } from "reselect";
+
 export const companySelector = (state) => {
   return state.stocks.tickerInfo.companyInfo;
 };
+
+export const companyBadgeInfoSelector = createSelector(
+  [companySelector],
+  (companyInfo) => {
+    return [companyInfo.exchange, companyInfo.sector, companyInfo.currency];
+  }
+);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -29,6 +29,9 @@ let companyJsonApple = {
   companyName: "Apple, Inc.",
   website: "./pal:.htc/twmoppwew",
   description: "Apple description",
+  exchange: "NASDAQ",
+  sector: "Technology",
+  currency: "USD",
 };
 
 let newsJsonApple = [
@@ -119,6 +122,9 @@ let companyJsonWork = {
   companyName: "Slack Technologies, Inc.",
   website: "c/thso/wlwptkwac.m.:",
   description: "Slack description",
+  exchange: "Other",
+  sector: "Technology",
+  currency: "USD",
 };
 
 let newsJsonWork = [

--- a/src/stockTrader.js
+++ b/src/stockTrader.js
@@ -2,6 +2,7 @@ import React from "react";
 import { DisplayWrapper } from "./components/generics/displayWrapper";
 import { KeyStats } from "./components/keyStats";
 import { CompanyOverview } from "./components/companyOverview";
+import { CompanyBadges } from "./components/companyBadges";
 import { LatestNews } from "./components/latestNews";
 import { SearchBar } from "./components/searchBar";
 import { Header } from "./components/header";
@@ -28,9 +29,8 @@ export const StockTrader = () => {
             <Header />
           </DisplayWrapper>
           <DisplayWrapper
-            mb="3.0rem"
             variant={["flexColumn", "flexRow", "flexRow"]}
-            paddingBottom="0.7rem"
+            paddingBottom="16px"
             borderBottom="0.2rem solid #6491d3"
             width="100%"
           >
@@ -42,6 +42,9 @@ export const StockTrader = () => {
               data={quote}
               size={["mediumLarge", "large", "large"]}
             />
+          </DisplayWrapper>
+          <DisplayWrapper variant="flexRow" mt="16px" mb="24px">
+            <CompanyBadges />
           </DisplayWrapper>
           <DisplayWrapper variant="flexColumn">
             <DisplayWrapper height="50%" variant="flexRow">


### PR DESCRIPTION
Implements kanbanize card 442

This PR adds three badges below the search bar with further company information, specifically the company exchange, sector, and currency traded in. It also adds basic unit testing for it, in the same approach as the other unit testing. I want to add a quick integration test for this once the work for that is merged.

![image](https://user-images.githubusercontent.com/36375152/89193191-9ec6b780-d573-11ea-996d-8cd9727baa55.png)
